### PR TITLE
- Dropping off the usage of utf8_encode;

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -96,7 +96,7 @@ final class Client
 	{
 		$local_path         = self::$path;
 		$local_path        .= str_replace('\\', '/', $path );
-		$local_pathEncoded  = utf8_encode($local_path);
+		$local_pathEncoded  = mb_convert_encoding($local_path, 'UTF-8');
 		$grf_path           = str_replace('/', '\\', $path );
 
 		Debug::write('Searching file ' . $path . '...', 'title');

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@
 		}
 
 		$filter = ini_get('magic_quotes_gpc') ? stripslashes($_POST['filter']) : $_POST['filter'];
-		$filter = utf8_decode('/'. $filter. '/i');
+		$filter = mb_convert_encoding('/'. $filter. '/i', 'UTF-8');
 		$list   = Client::search($filter);
 
 		die( implode("\n", $list) );
@@ -54,7 +54,7 @@
 
 
 	// Decode path
-	$path      = str_replace('\\', '/', utf8_decode(urldecode($_SERVER['REQUEST_URI'])));
+	$path      = str_replace('\\', '/', mb_convert_encoding(urldecode($_SERVER['REQUEST_URI']),'UTF-8'));
 	$path      = preg_replace('/\?.*/', '', $path); // remove query
 	$directory = basename(dirname(__FILE__));
 


### PR DESCRIPTION
- utf8_encode is deprecated on 8.2 and will be removed on PHP 9.0;
- mb_convert_encoding will be replacing it as a viable solution;


See [utf8_encode](https://www.php.net/utf8_encode)
See [mb_convert_encoding](https://www.php.net/manual/en/function.mb-convert-encoding.php)