### PR TITLE
feat: Add HTTP cache headers (ETag, 304 Not Modified)

### DIFF
--- a/HttpCache.php
+++ b/HttpCache.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * @fileoverview HTTP Cache Helper - Implements ETag and Cache-Control headers
+ * @author roBrowser Legacy Team
+ * @version 1.0.0
+ * 
+ * Provides HTTP caching functionality to reduce bandwidth and improve
+ * client-side performance through proper cache headers.
+ */
+
+class HttpCache
+{
+    /**
+     * Default max-age for Cache-Control (30 days in seconds)
+     */
+    const DEFAULT_MAX_AGE = 2592000;
+
+    /**
+     * Max-age for immutable game assets (1 year)
+     */
+    const IMMUTABLE_MAX_AGE = 31536000;
+
+    /**
+     * File extensions considered immutable (rarely change)
+     */
+    private static $immutableExtensions = array(
+        'grf', 'gat', 'gnd', 'rsw', 'rsm', 'spr', 'act', 'pal',
+        'wav', 'mp3', 'ogg', 'bmp', 'jpg', 'jpeg', 'png', 'gif', 'tga'
+    );
+
+    /**
+     * File extensions that should not be cached
+     */
+    private static $noCacheExtensions = array(
+        'php', 'ini'
+    );
+
+
+    /**
+     * Generate ETag from file content
+     *
+     * @param string $content File content
+     * @param string $path File path (optional, for additional uniqueness)
+     * @return string ETag value (quoted)
+     */
+    public static function generateETag($content, $path = '')
+    {
+        // Use MD5 for speed, combined with content length for extra uniqueness
+        $hash = md5($content);
+        $size = strlen($content);
+        return '"' . substr($hash, 0, 16) . '-' . dechex($size) . '"';
+    }
+
+
+    /**
+     * Check if client has valid cached version (conditional request)
+     *
+     * @param string $etag Current ETag value
+     * @return bool True if client cache is valid (should return 304)
+     */
+    public static function checkConditionalRequest($etag)
+    {
+        // Check If-None-Match header
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            $clientEtag = trim($_SERVER['HTTP_IF_NONE_MATCH']);
+            
+            // Handle multiple ETags (comma-separated)
+            $clientEtags = array_map('trim', explode(',', $clientEtag));
+            
+            foreach ($clientEtags as $tag) {
+                // Remove weak validator prefix if present
+                $tag = preg_replace('/^W\//', '', $tag);
+                
+                if ($tag === $etag || $tag === '*') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Send 304 Not Modified response
+     */
+    public static function sendNotModified()
+    {
+        header('HTTP/1.1 304 Not Modified', true, 304);
+        header('Status: 304 Not Modified', true, 304);
+        exit();
+    }
+
+
+    /**
+     * Set all cache headers for a file
+     *
+     * @param string $content File content
+     * @param string $path File path
+     * @param string $ext File extension
+     * @return string Generated ETag
+     */
+    public static function setCacheHeaders($content, $path, $ext)
+    {
+        $etag = self::generateETag($content, $path);
+        $ext = strtolower($ext);
+
+        // Check if this extension should not be cached
+        if (in_array($ext, self::$noCacheExtensions)) {
+            header('Cache-Control: no-store, no-cache, must-revalidate');
+            header('Pragma: no-cache');
+            return $etag;
+        }
+
+        // Set ETag
+        header('ETag: ' . $etag);
+
+        // Determine cache duration based on file type
+        if (in_array($ext, self::$immutableExtensions)) {
+            // Immutable assets - cache for 1 year
+            $maxAge = self::IMMUTABLE_MAX_AGE;
+            header('Cache-Control: public, max-age=' . $maxAge . ', immutable');
+        } else {
+            // Regular files - cache for 30 days
+            $maxAge = self::DEFAULT_MAX_AGE;
+            header('Cache-Control: public, max-age=' . $maxAge);
+        }
+
+        // Set Expires header (for HTTP/1.0 compatibility)
+        $expires = gmdate('D, d M Y H:i:s', time() + $maxAge) . ' GMT';
+        header('Expires: ' . $expires);
+
+        // Set Last-Modified to now (since we don't track file modification times in GRF)
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+        // Vary header for proper caching with different encodings
+        header('Vary: Accept-Encoding');
+
+        return $etag;
+    }
+
+
+    /**
+     * Process cache headers and check for conditional request
+     * Returns true if 304 response was sent (caller should exit)
+     *
+     * @param string $content File content
+     * @param string $path File path
+     * @param string $ext File extension
+     * @return bool True if 304 was sent
+     */
+    public static function processCache($content, $path, $ext)
+    {
+        $etag = self::setCacheHeaders($content, $path, $ext);
+
+        // Check if client has valid cache
+        if (self::checkConditionalRequest($etag)) {
+            self::sendNotModified();
+            return true; // Never reached, but for clarity
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Get content type for file extension
+     *
+     * @param string $ext File extension
+     * @return string MIME type
+     */
+    public static function getContentType($ext)
+    {
+        $ext = strtolower($ext);
+        
+        $mimeTypes = array(
+            // Images
+            'jpg'  => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'png'  => 'image/png',
+            'gif'  => 'image/gif',
+            'bmp'  => 'image/bmp',
+            'tga'  => 'image/x-tga',
+            
+            // Audio
+            'mp3'  => 'audio/mpeg',
+            'wav'  => 'audio/wav',
+            'ogg'  => 'audio/ogg',
+            
+            // Text/Data
+            'xml'  => 'application/xml',
+            'txt'  => 'text/plain',
+            'lua'  => 'text/x-lua',
+            'lub'  => 'application/octet-stream',
+            
+            // RO specific
+            'gat'  => 'application/x-ro-gat',
+            'gnd'  => 'application/x-ro-gnd',
+            'rsw'  => 'application/x-ro-rsw',
+            'rsm'  => 'application/x-ro-rsm',
+            'spr'  => 'application/x-ro-spr',
+            'act'  => 'application/x-ro-act',
+            'pal'  => 'application/x-ro-pal',
+            'str'  => 'application/x-ro-str',
+        );
+
+        return isset($mimeTypes[$ext]) ? $mimeTypes[$ext] : 'application/octet-stream';
+    }
+}

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@
 	require_once('Grf.php');
 	require_once('Bmp.php');
 	require_once('Client.php');
+	require_once('HttpCache.php');
 	$CONFIGS = require_once('configs.php');
 
     // Apply configs
@@ -72,6 +73,8 @@
 
 	// File not found, end.
 	if ($file === false) {
+		header('HTTP/1.1 404 Not Found', true, 404);
+		header('Cache-Control: no-store');
 		Debug::write('Failed, file not found...', 'error');
 		Debug::output();
 	}
@@ -80,22 +83,15 @@
 	}
 
 
-	header('Status: 200 OK', true, 200);
-	header("Cache-Control: max-age=2592000, public");
-	header("Expires: Sat, 31 Jan 2015 05:00:00 GMT");
+	// Process HTTP cache headers (ETag, Cache-Control, etc.)
+	// This will send 304 Not Modified if client has valid cached version
+	HttpCache::processCache($file, $path, $ext);
 
-	// Display appropriate header
-	switch ($ext) {
-		case 'jpg':
-		case 'jpeg': header('Content-type:image/jpeg');               break;
-		case 'bmp':  header('Content-type:image/bmp');                break;
-		case 'gif':  header('Content-type:image/gif');                break;
-		case 'xml':  header('Content-type:application/xml');          break;
-		case 'txt':  header('Content-type:text/plain');               break;
-		case 'lua':  header('Content-type:application/lua');          break;
-		case 'mp3':  header('Content-type:audio/mp3');                break;
-		default:     header('Content-type:application/octet-stream'); break;
-	}
+
+	header('Status: 200 OK', true, 200);
+
+	// Set content type
+	header('Content-type: ' . HttpCache::getContentType($ext));
 
 	// Output
 	if (Debug::isEnable()) {

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Because pushing directly the fullclient on a server/ftp can provoke some errors,
  - Extracting files directly from GRF archive (only version 0x200 supported for now - without DES encryption).
  - Converting BMP files to PNG to speed up the transfer.
  - Optimized to don't call any script if files are already extracted/converted (resource friendly).
+ - **HTTP Cache Headers** (ETag, Cache-Control, 304 Not Modified) for browser caching.
 
 ###Add your fullclient###
 
@@ -15,6 +16,21 @@ Just put your GRFs files and DATA.INI file in the `resources/` directory.
 Overwrite the `BGM/`, `data/` and `System/` directories with your own folders.
 
 **Note: to be sure to use a compatible version of your GRFs, download *GRF Builder* and repack them manually (Option > Repack type > Decrypt -> Repack), it will ensure the GRFs files are converted in the proper version**
+
+## Performance Features
+
+### HTTP Cache Headers
+
+The server implements proper HTTP cache headers for browser caching:
+
+- **ETag**: Content-based validation for conditional requests
+- **304 Not Modified**: Reduces bandwidth by validating client cache
+- **Cache-Control**: Optimized per file type
+  - Game assets (sprites, maps, etc.): 1 year with `immutable`
+  - Other files: 30 days
+- **Expires**: HTTP/1.0 compatibility
+
+This significantly reduces bandwidth and speeds up repeated requests, as unchanged files are served from browser cache.
 
 ## Running the Remote Client
 


### PR DESCRIPTION
- Add new HttpCache.php class with cache management utilities
- Implement ETag generation based on content hash
- Implement 304 Not Modified responses for conditional requests
- Optimize Cache-Control headers per file type:
  - Game assets (spr, act, gat, etc.): 1 year with 'immutable'
  - Regular files: 30 days
- Add proper Content-Type mapping for RO file formats
- Fix: Return proper 404 status for missing files
- Update readme.md with HTTP cache documentation

Features:
- ETag: Content-based validation using MD5 hash
- If-None-Match: Proper conditional request handling
- Cache-Control: immutable for game assets
- Expires: HTTP/1.0 compatibility
- Vary: Accept-Encoding for proper CDN caching

This significantly reduces bandwidth by allowing browsers to cache files and validate with conditional requests.