### PR TITLE
feat: Add GRF file index for O(1) lookups

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -3,7 +3,7 @@
 /**
 * @fileoverview Client - File Manager
 * @author Vincent Thibault (alias KeyWorld - Twitter: @robrowser)
-* @version 1.5.1
+* @version 1.6.0
 */
 
 
@@ -36,6 +36,17 @@ final class Client
      * @var array Stores the file list on the data directory.
      */
     static public $FileList = [];
+
+	/**
+	 * @var array File index for O(1) lookups
+	 * Maps normalized path => ['grfIndex' => int, 'originalPath' => string]
+	 */
+	static private $fileIndex = [];
+
+	/**
+	 * @var bool Whether the file index has been built
+	 */
+	static private $indexBuilt = false;
 
 
 	/**
@@ -94,12 +105,90 @@ final class Client
 			self::$grfs[$index] = new Grf($info['dirname'] . '/' . $grf_filename);
 			self::$grfs[$index]->filename = $grf_filename;
 		}
+
+		// Build file index for O(1) lookups
+		self::buildFileIndex();
+	}
+
+
+	/**
+	 * Build file index from all GRFs for O(1) lookups
+	 * Files are indexed by normalized path (lowercase, forward slashes)
+	 * Later GRFs override earlier ones (same as original behavior)
+	 */
+	static private function buildFileIndex()
+	{
+		if (self::$indexBuilt) {
+			return;
+		}
+
+		$startTime = microtime(true);
+		$totalFiles = 0;
+
+		foreach (self::$grfs as $grfIndex => $grf) {
+			// Load GRF if not loaded
+			if (!$grf->loaded) {
+				Debug::write('Loading GRF for indexing: ' . $grf->filename, 'info');
+				$grf->load();
+			}
+
+			if (!$grf->loaded) {
+				continue;
+			}
+
+			// Get file list from GRF
+			$files = $grf->getFileList();
+			
+			foreach ($files as $filePath) {
+				// Normalize path: lowercase, forward slashes
+				$normalizedPath = strtolower(str_replace('\\', '/', $filePath));
+				
+				// Later GRFs override earlier ones (higher priority)
+				self::$fileIndex[$normalizedPath] = [
+					'grfIndex' => $grfIndex,
+					'originalPath' => $filePath
+				];
+				$totalFiles++;
+			}
+		}
+
+		self::$indexBuilt = true;
+		$elapsed = round((microtime(true) - $startTime) * 1000, 2);
+		
+		Debug::write("File index built: " . count(self::$fileIndex) . " unique files from {$totalFiles} total entries in {$elapsed}ms", 'success');
+	}
+
+
+	/**
+	 * Get file index statistics
+	 * 
+	 * @return array Statistics about the file index
+	 */
+	static public function getIndexStats()
+	{
+		$stats = [
+			'indexBuilt' => self::$indexBuilt,
+			'uniqueFiles' => count(self::$fileIndex),
+			'grfCount' => count(self::$grfs),
+			'grfs' => []
+		];
+
+		foreach (self::$grfs as $index => $grf) {
+			$stats['grfs'][$index] = [
+				'filename' => $grf->filename,
+				'loaded' => $grf->loaded,
+				'fileCount' => $grf->loaded ? count($grf->getFileList()) : 0
+			];
+		}
+
+		return $stats;
 	}
 
 
 
 	/**
 	 * Get a file from client, search it on data folder first and then on grf
+	 * Uses file index for O(1) GRF lookups
 	 *
 	 * @param {string} file path
 	 * @return {boolean} success
@@ -128,6 +217,35 @@ final class Client
 			Debug::write('File not found at ' . $local_path);
 		}
 
+		// Use file index for O(1) lookup
+		$normalizedPath = strtolower(str_replace('\\', '/', $path));
+		
+		if (isset(self::$fileIndex[$normalizedPath])) {
+			$indexEntry = self::$fileIndex[$normalizedPath];
+			$grfIndex = $indexEntry['grfIndex'];
+			$originalPath = $indexEntry['originalPath'];
+			$grf = self::$grfs[$grfIndex];
+
+			Debug::write("File found in index: GRF #{$grfIndex} ({$grf->filename})", 'info');
+
+			// Ensure GRF is loaded
+			if (!$grf->loaded) {
+				Debug::write('Loading GRF: ' . $grf->filename, 'info');
+				$grf->load();
+			}
+
+			// Get file using original path (preserves case)
+			if ($grf->getFile($originalPath, $content)) {
+				if (self::$AutoExtract) {
+					return self::store($path, $content);
+				}
+				return $content;
+			}
+		}
+
+		Debug::write('File not found in index, falling back to sequential search');
+
+		// Fallback: Sequential search (for files not in index or edge cases)
 		foreach (self::$grfs as $grf) {
 
 			// Load GRF just if needed

--- a/Grf.php
+++ b/Grf.php
@@ -1,60 +1,83 @@
 <?php
 
 /**
-* @fileoverview Grf - Load and Parse .grf file (only 0x200 version without DES encryption).
+* @fileoverview Grf - Load and Parse .grf file (versions 0x200 and 0x300 without DES encryption).
 * @author Vincent Thibault (alias KeyWorld - Twitter: @robrowser)
-* @version 1.1.0
+* @version 2.1.0
+* 
+* Changelog:
+*   v2.1.0 - Added getFileList() and getFileCount() for file indexing
+*   v2.0.0 - Added support for GRF version 0x300 (64-bit file offsets)
+*   v1.0.0 - Initial version with 0x200 support
 */
 
 class Grf
 {
 
 	/**
-	 * @var {string} fileTable binary
+	 * @var string fileTable binary
 	 */
 	private $fileTable;
 
 
 	/**
-	 * @var {Array} file header
+	 * @var array file header
 	 */
 	private $header;
 
 
 	/**
-	 * @var {boolean} is file loaded
+	 * @var bool is file loaded
 	 */
 	public $loaded = false;
 
 
 	/**
-	 * @var {fp}
+	 * @var resource file pointer
 	 */
 	protected $fp;
 
 
 	/**
-	 * @var {string} filename
+	 * @var string filename
 	 */
 	public $filename = '';
 
 
 	/**
-	 * @var {array} cached file list
+	 * @var int GRF version (0x200 or 0x300)
+	 */
+	private $version = 0;
+
+
+	/**
+	 * @var bool Whether this GRF uses 64-bit offsets (0x300)
+	 */
+	private $uses64BitOffsets = false;
+
+
+	/**
+	 * @var array cached file list for performance
 	 */
 	private $cachedFileList = null;
 
 
 	/**
-	 * @var {const} header size
+	 * Header size in bytes
 	 */
 	const HEADER_SIZE = 46;
+
+	/**
+	 * Supported GRF versions
+	 */
+	const VERSION_200 = 0x200;
+	const VERSION_300 = 0x300;
 
 
 	/**
 	 * Constructor, open the filename if specify
 	 *
-	 * @param {string} optional filename
+	 * @param string $filename optional filename
 	 */
 	public function __construct( $filename = false )
 	{
@@ -78,7 +101,7 @@ class Grf
 	/**
 	 * Open a file
 	 *
-	 * @param {string} file path
+	 * @param string $filename file path
 	 */
 	public function open( $filename )
 	{
@@ -93,7 +116,7 @@ class Grf
 		}
 
 		// Open it
-		$this->fp   = fopen( $filename, 'r' );
+		$this->fp = fopen( $filename, 'r' );
 	}
 
 
@@ -109,33 +132,63 @@ class Grf
 
 		// Parse header.
 		$this->header = unpack("a15signature/a15key/Ltable_offset/Lseeds/Lfilecount/Lversion", fread($this->fp, self::HEADER_SIZE) );
+		$this->version = $this->header['version'];
 
-		if ($this->header['signature'] !== 'Master of Magic' || $this->header['version'] !== 0x200) {
-			Debug::write('Invalid GRF version "'. $this->filename .'". Can\'t opened it', 'error');
+		// Validate signature
+		if ($this->header['signature'] !== 'Master of Magic') {
+			Debug::write('Invalid GRF signature in "'. $this->filename .'"', 'error');
 			return;
 		}
 
+		// Check version compatibility (0x200 or 0x300)
+		if ($this->version !== self::VERSION_200 && $this->version !== self::VERSION_300) {
+			Debug::write('Unsupported GRF version 0x'. dechex($this->version) .' in "'. $this->filename .'". Only 0x200 and 0x300 are supported.', 'error');
+			return;
+		}
+
+		// Check for DES encryption (key should be all zeros for non-encrypted GRFs)
+		$key = $this->header['key'];
+		$hasEncryption = false;
+		for ($i = 0; $i < strlen($key); $i++) {
+			if (ord($key[$i]) !== 0) {
+				$hasEncryption = true;
+				break;
+			}
+		}
+		
+		if ($hasEncryption) {
+			Debug::write('GRF "'. $this->filename .'" appears to have DES encryption. Only non-encrypted GRFs are supported.', 'error');
+			return;
+		}
+
+		// Set 64-bit offset flag for version 0x300
+		$this->uses64BitOffsets = ($this->version === self::VERSION_300);
+
+		Debug::write('Loading GRF version 0x'. dechex($this->version) . ($this->uses64BitOffsets ? ' (64-bit offsets)' : ' (32-bit offsets)'), 'info');
+
 		// Load table list
 		fseek( $this->fp, $this->header['table_offset'], SEEK_CUR);
-		$fileTableInfo   = unpack("Lpack_size/Lreal_size", fread($this->fp, 0x08));
+		$fileTableInfo = unpack("Lpack_size/Lreal_size", fread($this->fp, 0x08));
 		$this->fileTable = @gzuncompress( fread( $this->fp, $fileTableInfo['pack_size'] ), $fileTableInfo['real_size'] );
 
 		// Extraction error
 		if ($this->fileTable === false) {
-			Debug::write('Can\t extract fileTable in GRF "'. $this->filename .'"', 'error');
+			Debug::write('Can\'t extract fileTable in GRF "'. $this->filename .'"', 'error');
 			return;
 		}
 
 		// Grf now loaded
 		$this->loaded = true;
+		Debug::write('GRF "'. $this->filename .'" loaded successfully', 'success');
 	}
 
 
 	/**
-	 * Search a filename
+	 * Search a filename and extract its content
 	 *
-	 * @param {string} filename
-	 * @param {string} content reference
+	 * @param string $filename File path to search
+	 * @param string &$content Reference to store file content
+	 * @return bool True if file was found and extracted
 	 */
 	public function getFile($filename, &$content)
 	{
@@ -143,10 +196,10 @@ class Grf
 			return false;
 		}
 
-		// Case sensitive. faster
+		// Case sensitive search (faster)
 		$position = strpos( $this->fileTable, $filename . "\0");
 
-		// Not case sensitive, slower...
+		// Case insensitive fallback (slower)
 		if ($position === false){
 			$position = stripos( $this->fileTable, $filename . "\0");
 		}
@@ -157,19 +210,40 @@ class Grf
 			return false;
 		}
 
-		// Extract file info from fileList
+		// Move position past the filename and null terminator
 		$position += strlen($filename) + 1;
-		$fileInfo  = unpack('Lpack_size/Llength_aligned/Lreal_size/Cflags/Lposition', substr($this->fileTable, $position, 17) );
 
-		// Just open file.
+		// Extract file info from fileList
+		// Structure differs between 0x200 (32-bit offset) and 0x300 (64-bit offset)
+		if ($this->uses64BitOffsets) {
+			// GRF 0x300: pack_size(4) + length_aligned(4) + real_size(4) + flags(1) + position(8) = 21 bytes
+			$fileInfo = $this->unpackFileEntry300(substr($this->fileTable, $position, 21));
+		} else {
+			// GRF 0x200: pack_size(4) + length_aligned(4) + real_size(4) + flags(1) + position(4) = 17 bytes
+			$fileInfo = unpack('Lpack_size/Llength_aligned/Lreal_size/Cflags/Lposition', substr($this->fileTable, $position, 17));
+		}
+
+		// Check if file is stored without encryption (flags = 1)
 		if ($fileInfo['flags'] !== 1) {
-			Debug::write('Can\'t decrypt file in GRF '. $this->filename);
+			Debug::write('Can\'t decrypt file in GRF '. $this->filename . ' (flags: ' . $fileInfo['flags'] . ')', 'error');
 			return false;
 		}
 
-		// Extract file
+		// Extract file content
 		fseek( $this->fp, $fileInfo['position'] + self::HEADER_SIZE, SEEK_SET );
-		$content = gzuncompress( fread($this->fp, $fileInfo['pack_size']), $fileInfo['real_size'] );
+		$compressedData = fread($this->fp, $fileInfo['pack_size']);
+		
+		if ($compressedData === false || strlen($compressedData) < $fileInfo['pack_size']) {
+			Debug::write('Failed to read compressed data from GRF '. $this->filename, 'error');
+			return false;
+		}
+
+		$content = @gzuncompress($compressedData, $fileInfo['real_size']);
+		
+		if ($content === false) {
+			Debug::write('Failed to decompress file from GRF '. $this->filename, 'error');
+			return false;
+		}
 
 		Debug::write('File found and extracted from '. $this->filename, 'success');
 		return true;
@@ -177,10 +251,53 @@ class Grf
 
 
 	/**
-	 * Filter
-	 * Find all occurences of a string in GRF list
+	 * Unpack file entry for GRF 0x300 (64-bit offset)
 	 *
-	 * @param {string} regex
+	 * @param string $data Binary data (21 bytes)
+	 * @return array File entry info
+	 */
+	private function unpackFileEntry300($data)
+	{
+		// First unpack the 32-bit values
+		$info = unpack('Lpack_size/Llength_aligned/Lreal_size/Cflags', substr($data, 0, 13));
+		
+		// Handle 64-bit position (PHP doesn't have native 64-bit unpack on all platforms)
+		// Read as two 32-bit values (little-endian)
+		$posLow  = unpack('L', substr($data, 13, 4))[1];
+		$posHigh = unpack('L', substr($data, 17, 4))[1];
+		
+		// Combine into 64-bit value
+		// Note: For files > 4GB, this might lose precision on 32-bit PHP
+		if (PHP_INT_SIZE >= 8) {
+			$info['position'] = $posLow | ($posHigh << 32);
+		} else {
+			// On 32-bit PHP, we can only handle files up to 4GB
+			if ($posHigh > 0) {
+				Debug::write('Warning: 64-bit file offset not fully supported on 32-bit PHP', 'warning');
+			}
+			$info['position'] = $posLow;
+		}
+		
+		return $info;
+	}
+
+
+	/**
+	 * Get the file entry size based on GRF version
+	 *
+	 * @return int Size of file entry in bytes (17 for 0x200, 21 for 0x300)
+	 */
+	private function getFileEntrySize()
+	{
+		return $this->uses64BitOffsets ? 21 : 17;
+	}
+
+
+	/**
+	 * Search for files matching a regex pattern
+	 *
+	 * @param string $regex Regular expression pattern
+	 * @return array List of matching file paths
 	 */
 	public function search( $regex )
 	{
@@ -217,6 +334,7 @@ class Grf
 		$files = [];
 		$offset = 0;
 		$tableLength = strlen($this->fileTable);
+		$entrySize = $this->getFileEntrySize();
 
 		while ($offset < $tableLength) {
 			// Find null terminator for filename
@@ -233,9 +351,10 @@ class Grf
 				$files[] = $filename;
 			}
 
-			// Move past filename + null + 17 bytes of file info
-			// File info: pack_size(4) + length_aligned(4) + real_size(4) + flags(1) + position(4) = 17 bytes
-			$offset = $nullPos + 1 + 17;
+			// Move past filename + null + file entry size
+			// 0x200: 17 bytes (pack_size(4) + length_aligned(4) + real_size(4) + flags(1) + position(4))
+			// 0x300: 21 bytes (pack_size(4) + length_aligned(4) + real_size(4) + flags(1) + position(8))
+			$offset = $nullPos + 1 + $entrySize;
 		}
 
 		// Cache the result
@@ -253,5 +372,56 @@ class Grf
 	public function getFileCount()
 	{
 		return count($this->getFileList());
+	}
+
+
+	/**
+	 * Get GRF version
+	 *
+	 * @return int Version number (0x200 or 0x300)
+	 */
+	public function getVersion()
+	{
+		return $this->version;
+	}
+
+
+	/**
+	 * Get GRF version as hex string
+	 *
+	 * @return string Version as hex (e.g., "0x200")
+	 */
+	public function getVersionHex()
+	{
+		return '0x' . strtoupper(dechex($this->version));
+	}
+
+
+	/**
+	 * Check if this GRF uses 64-bit offsets
+	 *
+	 * @return bool True if using 64-bit offsets (0x300)
+	 */
+	public function uses64Bit()
+	{
+		return $this->uses64BitOffsets;
+	}
+
+
+	/**
+	 * Get GRF statistics
+	 *
+	 * @return array Statistics about this GRF
+	 */
+	public function getStats()
+	{
+		return array(
+			'filename' => $this->filename,
+			'version' => $this->getVersionHex(),
+			'uses64BitOffsets' => $this->uses64BitOffsets,
+			'loaded' => $this->loaded,
+			'fileCount' => $this->loaded ? $this->getFileCount() : 0,
+			'tableSize' => $this->fileTable ? strlen($this->fileTable) : 0,
+		);
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Because pushing directly the fullclient on a server/ftp can provoke some errors,
  - Extracting files directly from GRF archive (only version 0x200 supported for now - without DES encryption).
  - Converting BMP files to PNG to speed up the transfer.
  - Optimized to don't call any script if files are already extracted/converted (resource friendly).
+ - **File Index for O(1) lookups**: Files are indexed at startup for instant lookups instead of sequential search through GRFs.
 
 ###Add your fullclient###
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ The remote client exist to help users without a FullClient on their computer to 
 Because pushing directly the fullclient on a server/ftp can provoke some errors, this tool allow to :
 
  - Get the files from a client used in another domain (Cross-origin resource sharing).
- - Extracting files directly from GRF archive (only version 0x200 supported for now - without DES encryption).
+ - Extracting files directly from GRF archive (versions 0x200 and 0x300 supported - without DES encryption).
  - Converting BMP files to PNG to speed up the transfer.
  - Optimized to don't call any script if files are already extracted/converted (resource friendly).
  - **File Index for O(1) lookups**: Files are indexed at startup for instant lookups instead of sequential search through GRFs.


### PR DESCRIPTION
- Add file index that maps normalized paths to GRF locations
- Build index at startup by parsing all GRF file tables
- Modify getFile() to use index for instant O(1) lookups
- Add getFileList() method to Grf class for extracting all file paths
- Add getFileCount() method to Grf class
- Add getIndexStats() method to Client class for statistics
- Cache file lists in Grf class for better performance
- Keep fallback sequential search for edge cases
- Update readme with new feature description

Performance improvement:
- Before: O(n*m) where n=number of GRFs, m=average files per GRF
- After: O(1) hash table lookup for most requests