### PR TITLE
fix: uses correct filename GrfDES.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 require_once('Debug.php');
 require_once('LRUCache.php');
 require_once('Grf.php');
-require_once('GrfDes.php');
+require_once('GrfDES.php');
 require_once('Bmp.php');
 require_once('Client.php');
 require_once('Compression.php');


### PR DESCRIPTION
Update index.php to require GrfDES.php instead of GrfDes.php to match the actual file name/case. This prevents include/require failures on case-sensitive filesystems.